### PR TITLE
Fixes to sqls to convert between browser and OS database timezone.

### DIFF
--- a/dbhist_viewer/algorithm_to_handle_derived_metrics.log
+++ b/dbhist_viewer/algorithm_to_handle_derived_metrics.log
@@ -1,0 +1,94 @@
+-- Algorithm to Handle *Derived metrics:
+
+-- Issue:
+   Certain statistics in DBA_HIST_SYSMETRIC_HISTORY and DBA_HIST_SYSMETRIC_SUMMARY do not have
+   "Per Second" metrics but have only "Per Txn" metrics.
+   For example, there are records with "Logical Reads Per Txn"
+   but there are no records with "Logical Reads Per Sec".
+   
+   We will derive "Per Sec" values from "Per Txn" multiplied by "User Txn Per Sec".
+
+-- In below example SQL 
+	"*- Derived" -> converted to "*Per Txn" in two *in* clauses
+				\-> converted to "*Per Txn"*"User Txn Per Sec" in pivot select clause
+
+-- example:
+-- front end requests two metrics:
+	'Logical Reads Per Sec - Derived'
+	and
+	'Redo Generated Per Sec'
+			
+with pivot_data AS (
+select to_char(round(begin_time,'MI'),'YYYY/MM/DD HH24:MI:SS') as begin_time
+     , trunc(value,2) as value
+     , metric_name
+from DBA_HIST_SYSMETRIC_HISTORY
+where metric_name in ( 'Logical Reads Per Txn','Redo Generated Per Sec', 'User Transaction Per Sec')
+					-- *Derived metrics is replaced with *Per Txn metrics
+					-- User Transaction per sec metric added
+and instance_number=1
+and begin_time between sysdate-2 and sysdate
+)
+select begin_time, f1*TPS, f2
+					-- Derived is calculated here
+from pivot_data
+pivot
+     ( sum(value)
+       for metric_name
+       in ( 'Logical Reads Per Txn' as f1,'Redo Generated Per Sec' as f2, 'User Transaction Per Sec' as TPS)
+					-- *Derived metrics is replaced with *Per Txn metrics
+					-- User Transaction per sec metric added
+					-- aliases added
+      )
+order by begin_time desc;
+
+
+select begin_time, trunc(value*val_txn_sec,2) as value
+from (
+	select to_char(begin_time,'YYYY/MM/DD HH24:MI:SS') as begin_time
+		,trunc(value,2) as value
+		, metric_name
+		,lead(value) over (partition by begin_time order by metric_name) as VAL_TXN_SEC
+	from DBA_HIST_SYSMETRIC_HISTORY
+	where metric_name in ( :1, 'User Transaction Per Sec')
+	and instance_number=1
+	and begin_time between sysdate-2 and sysdate
+	order by begin_time desc, metric_name
+) where metric_name = :1
+
+
+-- here is how to aggregate *Derived over all RAC instances
+-- when request also asks some non-derived metrics:
+
+with pivot_data AS (
+select to_char(round(begin_time,'MI'),'YYYY/MM/DD HH24:MI:SS') as begin_time
+     , trunc(value,2) as value
+     , metric_name || ' - instance' || instance_number as metric_name
+from DBA_HIST_SYSMETRIC_HISTORY
+where metric_name in ( 'Logical Reads Per Txn'
+                      ,'Redo Generated Per Sec'
+					  ,'User Transaction Per Sec')
+and begin_time between sysdate-2 and sysdate
+)
+select 
+    -- if all-aggregate:
+	begin_time
+	,f11*TPS1+f12*TPS2 as Derived   -- this aggregates 'Logical Reads Per Sec - Derived'
+	,f21+f22 as non_derived		    -- this aggregates 'Redo Generated Per Sec'
+    -- if all-stacked:
+    --select begin_time,f11*TPS1,f12*TPS2,f21,f22
+	-- if single instance1:
+	--select begin_time,f11*TPS1,f21
+from pivot_data
+pivot
+     ( sum(value)
+       for metric_name
+       in ( 'User Transaction Per Sec - instance1' as TPS1
+	       ,'User Transaction Per Sec - instance2' as TPS2
+		   ,'Logical Reads Per Txn - instance1' as f11,
+           ,'Logical Reads Per Txn - instance2' as f12,
+           ,'Redo Generated Per Sec - instance1' as f21
+           ,'Redo Generated Per Sec - instance2' as f22)
+      )
+order by begin_time desc
+			   

--- a/dbhist_viewer/build_summary_sql_str.py
+++ b/dbhist_viewer/build_summary_sql_str.py
@@ -3,7 +3,7 @@
 # this will populate summary chart
 # The logic is exactly the same as in build_detail_sql, just different source table
 #--  
-def build_summary_sql(rac_instances, selected_instance, metric_list, browzer_tz_name):
+def build_summary_sql(rac_instances, selected_instance, metric_list, browzer_tz_name,db_os_tz):
     
     # Algorithm to aggregate *Derived metrics over all instances:
     #
@@ -57,7 +57,7 @@ def build_summary_sql(rac_instances, selected_instance, metric_list, browzer_tz_
                     -- round begin_time to closest 10 min
                     to_char(
                         round((
-                            cast((from_tz(cast(begin_time as timestamp),DBTIMEZONE) at time zone '{str5}') as date)
+                            cast((from_tz(cast(begin_time as timestamp),'{str6}') at time zone '{str5}') as date)
                             - trunc(begin_time))*60*24,-1)/(60*24)
                             + trunc(begin_time)
                         ,'YYYY/MM/DD HH24:MI:SS') as begin_time
@@ -74,7 +74,7 @@ def build_summary_sql(rac_instances, selected_instance, metric_list, browzer_tz_
                     for metric_name
                     in ( {str3} )
                     )
-                order by begin_time desc""".format(str1=str1_with_in, str2=str2_pivot_select, str3=str3_pivot_in, str4=str4_instance, str5=browzer_tz_name)
+                order by begin_time desc""".format(str1=str1_with_in, str2=str2_pivot_select, str3=str3_pivot_in, str4=str4_instance, str5=browzer_tz_name, str6=db_os_tz)
                
     return v_sql
 

--- a/dbhist_viewer/static/graph.js
+++ b/dbhist_viewer/static/graph.js
@@ -189,8 +189,7 @@ export function getDateRange() {
 // Returns millisec since epoch in browser timezone
 //
 function getDateRangeMs() {
-	var tzOffsetMs=new Date().getTimezoneOffset()*60*1000;
-	//tzOffsetMs=0;
+	//var tzOffsetMs=new Date().getTimezoneOffset()*60*1000;
 	// following https://danielcompton.net/2017/07/06/detect-user-timezone-javascript
 	//tzName=Intl.DateTimeFormat().resolvedOptions().timeZone;
 	
@@ -231,7 +230,8 @@ function getDateRangeMs() {
 		// end date can not be in the future
 		endDate = Math.min(endDate, (new Date()).getTime());
 
-		return [beginDate-tzOffsetMs, endDate-tzOffsetMs];
+		//return [beginDate-tzOffsetMs, endDate-tzOffsetMs];
+		return [beginDate, endDate];
 	}
 }
 	

--- a/dbhist_viewer/static/sqlMonitorDataTable.js
+++ b/dbhist_viewer/static/sqlMonitorDataTable.js
@@ -6,7 +6,8 @@ import {getDateRange} from "./graph.js"
 export function loadSqlMonData() {
 	$.post(gl.api_root+'/get_sql_monitor_object', 
 		  {conn_name: gl.gDbCredential
-		  ,browzer_tz_name: Intl.DateTimeFormat().resolvedOptions().timeZone},
+		  ,browzer_tz_name: Intl.DateTimeFormat().resolvedOptions().timeZone
+		  },
 		  function(data) {
 			gl.gSqlMonitorData=data;
 			createSqlMonDataTable();
@@ -20,7 +21,7 @@ export function createSqlMonDataTable() {
 	var dataRange=gl.gSqlMonitorData
 				.filter(function(row){
 					//var rowDate=new Date(row[0]);
-					var rowDate=new Date(row.SQL_EXEC_START);
+					var rowDate=new Date(row.SQL_EXEC_START_BROWSER_TZ);
 					return (rowDate > visibleBeginDate 
 							&&
 							rowDate < visibleEndDate)
@@ -43,7 +44,7 @@ export function createSqlMonDataTable() {
 				  }
 				 ,"width":"15px"
 				 }
-				,{ "data": "SQL_EXEC_START" }
+				,{ "data": "SQL_EXEC_START_BROWSER_TZ" }
 				,{ "data": "ELAPSED_TIME"   }
 				,{ "data": "STATUS"         }
 				,{ "data": "SQL_ID"         }
@@ -53,10 +54,9 @@ export function createSqlMonDataTable() {
 			,searching:			false
 			,deferRender:		true
 			,scrollY:			300
-			,scrollX:			false
-			,scroller:			true
-			,paging:			true
-			//,scrollCollapse:	true
+			,scrollX:			true
+			,scroller:			false
+			,paging:			false
 		} 
 	);
 	
@@ -71,7 +71,7 @@ export function createSqlMonDataTable() {
 	$('.sqlmonitor_datatable tbody')
 		.off('mouseenter')
 		.on( 'mouseenter', 'tr.odd, tr.even', function () {
-			var sqlExecStart=gl.gDataTbl.row(this).data()["SQL_EXEC_START"];
+			var sqlExecStart=gl.gDataTbl.row(this).data()["SQL_EXEC_START_BROWSER_TZ"];
 			sqlExecStart=new Date(sqlExecStart).getTime();
 			var elapsedTime=gl.gDataTbl.row(this).data()["ELAPSED_TIME"];
 			gl.dg.updateOptions(
@@ -161,7 +161,7 @@ function formatDataTableChildRow1(rowData, rowIcon){
 					.text(data)
 					.popup('show');
 							
-					// give 100ms for popup to draw before scrolling to the top
+					// give 80ms for popup to draw before scrolling to the top
 		            setTimeout(function() {
 						$txtArea.animate({ scrollTop: 0, scrollLeft: 0 });
 					}, 80);

--- a/dbhist_viewer/to_do.log
+++ b/dbhist_viewer/to_do.log
@@ -1,0 +1,36 @@
+---------
+-- to do list:
+---------
+
+done: 1. when selecting new connection - recreate empty graph and clear metrics list (it already re-builds easyautocomplete)
+done: 2. when removing last selected metrics also empty the graph
+done: 3. color selected metrics in the chart colors
+done: 4. sql: modify to include derived items
+done: 4a sql: modify to replace null with something (check dygraph doc - NaN ??)
+done: 5. move out event logic into a function
+5. can i compare charts from diff databases ?
+    This would require combining datasets on client, i.e. in javascript; may be slow ??
+	alternatively can be combined in python after selecting from several databases; 
+	this may also be slow since there will be no data streaming
+6. add "to remove metrics from chart click on metric below" on the bottom
+done: 7. add units on the bottom 
+done: 8. prevent from selecting second time already selected metrics
+9. make static "Overview" tab with Logical Reads per Sec, Redo per Sec, Physical
+10. display error when python can not connect to oracle (like ewptsdb_prod with no tunnel)
+10a. why datapoint hover overlay is outside of the chart ?
+done: 11. Title and Units labels are misleading on multi-series chart
+done: 12. multi-instance (RAC): add inst_id checkbox on bottom; 
+done: 13: add "ALL" instances in sql; for derived it is tricky
+done: 14: add SQL_MONITOR datatable
+15: repaint SQL_MONITOR on zoomEnd and panEnd events
+	There are no such events; 
+	check https://groups.google.com/forum/#!topic/dygraphs-users/I-wNDXZjCls
+	check http://kaliatech.github.io/dygraphs-dynamiczooming-example/
+done: 16: shade area on chart while hovering over sql in SQL_MONITOR datatable
+17: to speed up chart loading time:
+	separate data for full range from data for visible dateWindow
+		for full range - take from DBA_HIST_SYSMETRIC_SUMMARY where its aggregated by AWR snap
+		for visible viewport - take from DBA_HIST_SYSMETRIC_HISTORY
+		splice the two data sources before feeding to dyGraph
+	follow http://kaliatech.github.io/dygraphs-dynamiczooming-example/
+

--- a/start_app.bat
+++ b/start_app.bat
@@ -4,7 +4,7 @@ rem
 docker run -d --rm ^
 --name app ^
 -p 0.0.0.0:5000:5000 ^
--v %CD%/dbhist_viewer:/app ^
+-v "%CD%\dbhist_viewer":/app ^
 -e db_ora122="system/Oradoc_db1@oradb:1521/ORCLCDB.localdomain" ^
 -e PYTHONUNBUFFERED=1 ^
 --link ora122:oradb ^


### PR DESCRIPTION
Changed date format in sqlmonitor select from 12hr to 24hr.

GV$SQLMONITOR select, DBA_HIST_SYSMETRIC_HISORY select and DBA_HIST_SYSMETRIC_SUMMARY select
now convert from browser time zone to database OS timezone in where clauses.

SQL now return dates in browser time zone.

jQuery datatable now scrolls header when table is horizontally scrolled.